### PR TITLE
Fix dependencies errors with latest Python version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 venv
+*.pyc
+.DS_Store
 build
 dist
 .idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,18 @@
 [tool.poetry]
 name = "py-near"
 version = "1.1.49"
-description="Pretty simple and fully asynchronous framework for working with NEAR blockchain"
+description = "Pretty simple and fully asynchronous framework for working with NEAR blockchain"
 authors = ["pvolnov <petr@herewallet.app>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-ed25519 = "1.5"
 httpx = "0.26.0"
 py-near-primitives = "0.2.3"
+frozenlist = "^1.4.1"
+pynacl = "^1.5.0"
+loguru = "^0.7.2"
+pydantic = "^2.6.2"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"
@@ -21,13 +24,14 @@ sphinx-rtd-theme = "^1.0.0"
 base58 = "^2.1.1"
 
 [project]
+
 name = "py-near"
 version = "1.1.49"
 description = "Pretty simple and fully asynchronous framework for working with NEAR blockchaink"
-authors = [ {name = "pvolnov", email = "petr@herewallet.app"} ]
-requires-python = ">=3.7"
-license = {file = "LICENSE"}
-dependencies=["base58", "ed25519", "httpx", "py-near-primitives", "pydantic"]
+authors = [{ name = "pvolnov", email = "petr@herewallet.app" }]
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+dependencies = ["base58", "aiohttp", "py-near-primitives", "pydantic"]
 keywords = ["python", "near", "async"]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,15 @@ authors = ["pvolnov <petr@herewallet.app>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.10"
 httpx = "0.26.0"
 py-near-primitives = "0.2.3"
 frozenlist = "^1.4.1"
 pynacl = "^1.5.0"
 loguru = "^0.7.2"
 pydantic = "^2.6.2"
+base58 = "^2.1.1"
+aiohttp = "^3.9.5"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"
@@ -21,7 +23,6 @@ pytest = "^6.2.5"
 flake8 = "^4.0.1"
 Sphinx = "^4.3.2"
 sphinx-rtd-theme = "^1.0.0"
-base58 = "^2.1.1"
 
 [project]
 

--- a/src/py_near/account.py
+++ b/src/py_near/account.py
@@ -13,7 +13,7 @@ else:
     from collections import MutableSet
 
 import base58
-import ed25519
+from nacl import signing, encoding
 from loguru import logger
 from py_near_primitives import DelegateAction
 
@@ -85,10 +85,8 @@ class Account(object):
                 except UnicodeEncodeError:
                     logger.error(f"Can't decode private key {pk[:10]}")
                     continue
-            private_key = ed25519.SigningKey(pk)
-            public_key = base58.b58encode(
-                private_key.get_verifying_key().to_bytes()
-            ).decode("utf-8")
+            private_key = signing.SigningKey(pk[:32], encoder=encoding.RawEncoder)
+            public_key = private_key.verify_key
             self._signer_by_pk[public_key] = pk
             self._free_signers.put_nowait(pk)
             self._signers.append(pk)
@@ -206,11 +204,12 @@ class Account(object):
         if pk is None:
             pk = self._signers[0]
 
-        private_key = ed25519.SigningKey(pk)
-        public_key = private_key.get_verifying_key()
+        private_key = signing.SigningKey(pk[:32], encoder=encoding.RawEncoder)
+        public_key = private_key.verify_key
+        public_key.to_curve25519_public_key()
 
         resp = await self._provider.get_access_key(
-            self.account_id, base58.b58encode(public_key.to_bytes()).decode("utf8")
+            self.account_id, base58.b58encode(public_key.encode()).decode("utf8")
         )
         if "error" in resp:
             raise ValueError(resp["error"])
@@ -449,8 +448,8 @@ class Account(object):
         access_key = await self.get_access_key(pk)
         await self._update_last_block_hash()
 
-        private_key = ed25519.SigningKey(pk)
-        verifying_key = private_key.get_verifying_key()
+        private_key = signing.SigningKey(pk[:32], encoder=encoding.RawEncoder)
+        verifying_key = private_key.verify_key
         return DelegateActionModel(
             sender_id=self.account_id,
             receiver_id=receiver_id,
@@ -479,7 +478,7 @@ class Account(object):
         if public_key not in self._signer_by_pk:
             raise ValueError(f"Public key {public_key} not found in signer list")
 
-        private_key = ed25519.SigningKey(self._signer_by_pk[public_key])
+        private_key = signing.SigningKey(self._signer_by_pk[public_key], encoder=encoding.RawEncoder)
         sign = private_key.sign(nep461_hash)
         return base58.b58encode(sign).decode("utf-8")
 

--- a/src/py_near/transactions.py
+++ b/src/py_near/transactions.py
@@ -1,8 +1,7 @@
 import base64
 from typing import Union, List
-
+from nacl import signing, encoding
 import base58
-import ed25519
 from py_near_primitives import (
     CreateAccountAction,
     AddKeyAction,
@@ -34,11 +33,11 @@ def sign_and_serialize_transaction(
         pk = base58.b58decode(private_key.replace("ed25519:", ""))
     else:
         pk = private_key
-    private_key = ed25519.SigningKey(pk)
+    private_key = signing.SigningKey(pk[:32], encoder=encoding.RawEncoder)
 
     transaction = Transaction(
         account_id,
-        private_key.get_verifying_key().to_bytes(),
+        private_key.verify_key.encode(),
         nonce,
         receiver_id,
         block_hash,
@@ -61,11 +60,11 @@ def calc_trx_hash(
         pk = base58.b58decode(private_key.replace("ed25519:", ""))
     else:
         pk = private_key
-    private_key = ed25519.SigningKey(pk)
+    private_key = signing.SigningKey(pk[:32], encoder=encoding.RawEncoder)
 
     transaction = Transaction(
         account_id,
-        private_key.get_verifying_key().to_bytes(),
+        private_key.verify_key.encode(),
         nonce,
         receiver_id,
         block_hash,


### PR DESCRIPTION
This PR fixes some dependencies issues I found while using this project during the ETHGlobal Brussels 2024 hackathon.

It includes the switch to pynacl made in #19, along with the addition of `aiohttp` as an explicit dependency.

cc @gagdiez