### PR TITLE
Incompatible python version with httpx. added loguru to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ authors = ["pvolnov <petr@herewallet.app>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 ed25519 = "1.5"
+loguru = "0.7.2"
 httpx = "0.26.0"
 py-near-primitives = "0.2.3"
 


### PR DESCRIPTION
Added `loguru` to dependencies.

Resolving incompatible python version with httpx:
```bash
(clean-venv) edwinpaco@Edwins-MacBook-Pro-2 py-near % poetry lock   
Updating dependencies
Resolving dependencies... (0.2s)

The current project's supported Python range (>=3.7,<4.0) is not compatible with some of the required packages Python requirement:
  - httpx requires Python >=3.8, so it will not be satisfied for Python >=3.7,<3.8

Because py-near depends on httpx (0.26.0) which requires Python >=3.8, version solving failed.

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
    
    For httpx, a possible solution would be to set the `python` property to ">=3.8,<4.0
```