### PR TITLE
docs(account/get_access_key_list): Remove outdated description line

### DIFF
--- a/docs/account.rst
+++ b/docs/account.rst
@@ -85,7 +85,6 @@ Documentation
 
 .. function:: get_access_key_list(account_id=None)
 
-    Send fungible token to phone number. Receiver will get sms with link to claim tokens.
     Get access key list for account_id, if account_id is None, get access key list for current account
 
     :param account_id: if account_id is None, return balance of current account
@@ -262,6 +261,3 @@ Documentation
     Get client for fungible tokens
 
     :return: FT(self)
-
-
-


### PR DESCRIPTION
Remove a line that was probably intended for another method that has been removed since.