### PR TITLE
changed pynear to py_near

### DIFF
--- a/docs/account.rst
+++ b/docs/account.rst
@@ -6,9 +6,9 @@ Quick start
 -----------
 .. code:: python
 
-    from pynear.account import Account
+    from py_near.account import Account
     import asyncio
-    from pynear.dapps.core import NEAR
+    from py_near.dapps.core import NEAR
 
     ACCOUNT_ID = "bob.near"
     PRIVATE_KEY = "ed25519:..."

--- a/docs/clients/fungible-token.rst
+++ b/docs/clients/fungible-token.rst
@@ -8,8 +8,8 @@ Quick start
 
 .. code:: python
 
-    from pynear.account import Account
-    from pynear.dapps.fts import FTS
+    from py_near.account import Account
+    from py_near.dapps.fts import FTS
     import asyncio
 
     ACCOUNT_ID = "bob.near"

--- a/docs/clients/staking.rst
+++ b/docs/clients/staking.rst
@@ -13,8 +13,8 @@ Quick start
 
 .. code:: python
 
-    from pynear.account import Account
-    from pynear.dapps.fts import FTS
+    from py_near.account import Account
+    from py_near.dapps.fts import FTS
     import asyncio
 
     ACCOUNT_ID = "bob.near"

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ At first you have to import all necessary modules
 
 .. code:: python
 
-    from pynear.account import Account
+    from py_near.account import Account
 
 Then you have to initialize `Account`
 
@@ -23,7 +23,7 @@ Next step: check account balance
 .. code:: python
 
     import asyncio
-    from pynear.dapps.core import NEAR
+    from py_near.dapps.core import NEAR
 
     async def main():
         await acc.startup()
@@ -61,9 +61,9 @@ Summary
 
 .. code:: python
 
-    from pynear.account import Account
+    from py_near.account import Account
     import asyncio
-    from pynear.dapps.core import NEAR
+    from py_near.dapps.core import NEAR
 
     ACCOUNT_ID = "bob.near"
     PRIVATE_KEY = "ed25519:..."


### PR DESCRIPTION
The pypi version py-near uses py_near as the module name. using pynear gives out ModuleNotFound Error.